### PR TITLE
Fix snek exchange links

### DIFF
--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -49,7 +49,7 @@ const config: MenuEntry[] = [
     items: [
       {
         label: 'Exchange',
-        href: 'https://exchange.snek.farm/#/swap',
+        href: 'https://exchange.snek.farm/#/swap?outputCurrency=0x6e74c976e67feae8e83635936ef79f969e14e869',
       },
       {
         label: 'Liquidity',

--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -49,11 +49,11 @@ const config: MenuEntry[] = [
     items: [
       {
         label: 'Exchange',
-        href: 'https://exchange.mouse.farm/#/swap',
+        href: 'https://exchange.snek.farm/#/swap',
       },
       {
         label: 'Liquidity',
-        href: 'https://exchange.mouse.farm/#/pool',
+        href: 'https://exchange.snek.farm/#/pool',
       },
     ],
   },


### PR DESCRIPTION
Snek Farm was redirecting to `exchange.mouse.farm` when clicking the Trade buttons.